### PR TITLE
Deprecation warning for importing from collections instead of collections.abc

### DIFF
--- a/apitoolbox/models/base.py
+++ b/apitoolbox/models/base.py
@@ -1,7 +1,7 @@
 """ SQLAlchemy helper function """
 import uuid
 import enum
-from collections import Mapping
+from collections.abc import Mapping
 
 import sqlalchemy
 


### PR DESCRIPTION
import from collections.abc