### PR TITLE
Mapping Depreciated on Collections

### DIFF
--- a/apitoolbox/models/base.py
+++ b/apitoolbox/models/base.py
@@ -1,7 +1,7 @@
 """ SQLAlchemy helper function """
 import uuid
 import enum
-from collections import Mapping
+from collections.abc import Mapping
 
 import sqlalchemy
 


### PR DESCRIPTION
As of Python 3.10, Mapping will be depreciated on `collections`

Added `collections.abc` since Abstract Classes will be on there now.